### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
  
-#What is A3ParallaxScrollView?
+# What is A3ParallaxScrollView?
 **A3ParallaxScrollView** is a `UIScrollView` subclass with a parallax scrolling effect on iPhone and iPad.  
 
 It is written in *Objective-C* and works for all iOS applications using ARC.
 
-##Video:
+## Video:
 Here are two examples of the use of **A3ParallaxScrollView**.  
 The first is a little Demo with a lot of views and additional custom transformations (sine movement of the moon).  
 The other one shows a *Path* like scrolling behaviour.  
@@ -12,20 +12,20 @@ The other one shows a *Path* like scrolling behaviour.
 ![A3ParallaxScrollView Path like sample](https://dl.dropbox.com/u/9934540/aaa/A3ParallaxScrollViewPathSample.gif "A3ParallaxScrollView Path like Sample Video")  
 Both sample projects are included in the github repository.
 
-##Installation
+## Installation
 
-###With CocoaPods:
+### With CocoaPods:
 A3ParallaxScrollView is available on [CocoaPods](http://cocoapods.org) . Just add the following to your project Podfile:
 
-####Podfile
+#### Podfile
 	platform :ios, '7.0'
 	pod "A3ParallaxScrollView", "~> 1.0"
 	
 	
-###Manualy:
+### Manualy:
 Download the `A3ParallaxScrollView.h/.m` files and add them to your Project. There are no dependencies.
 
-##Usage:
+## Usage:
 Include **A3ParallaxScrollView** by the folowing import.
 
 	#import "A3ParallaxScrollView.h"
@@ -41,10 +41,10 @@ Or you can simply add a subview to your **A3ParallaxScrollView** and set his acc
 
 `- (void)setAcceleration:(CGPoint) acceleration forView:(UIView *)view`
  
-#License:
+# License:
 [See our MIT License](https://github.com/allaboutapps/A3ParallaxScrollView/blob/master/LICENSE)
 
-#Contribute:
+# Contribute:
 Feel free to fork and make pull requests! We are also very happy if you tell us about your app(s) which use this control.  
 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
